### PR TITLE
Avoid abstract conflicts

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -431,7 +431,7 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
                     [columns addObject:typeColumn];
                     
                     // Create the join
-                    NSString *join = [NSString stringWithFormat:@" INNER JOIN %@ ON %@.__objectid=%@.%@", destinationTable, destinationTable, table, column];
+                    NSString *join = [NSString stringWithFormat:@" INNER JOIN %@ AS %@ ON %@.__objectid=%@.%@", destinationTable, destinationEntity.name, destinationEntity.name, table, column];
                     [typeJoins addObject:join];
                     
                     // Mark that this relation needs a type lookup


### PR DESCRIPTION
Avoid abstract conflicts when there is more than one table in the INNER JOIN that inherence from the same abstract.
